### PR TITLE
Changed IntlWrapper to be a stateless component

### DIFF
--- a/src/intlWrapper.js
+++ b/src/intlWrapper.js
@@ -4,15 +4,12 @@ import { IntlProvider } from "react-intl";
 import intlStore from "./intl.store";
 
 export default function intlWrapper( Component ) {
-	class IntlWrapper extends React.Component {
-		render() {
-			const props = Object.assign( this.props, this.state );
-			return React.createElement(
-				IntlProvider,
-				props,
-				React.createElement( Component, props )
-			);
-		}
+	function IntlWrapper( props ) {
+		return React.createElement(
+			IntlProvider,
+			props,
+			React.createElement( Component, props )
+		);
 	}
 
 	IntlWrapper.displayName = `IntlWrapper(${ Component.displayName || "Component" })`;


### PR DESCRIPTION
@dcneiner pointed out that this line would be modifying props in place, but is also not necessary as it is uses `luxWrapper` and will just get props passed to it.

`const props = Object.assign( this.props, this.state );`

@rogueneiner also mentioned that it could be a stateless component
